### PR TITLE
Individual app pages and screenshot uploading

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,5 @@
 Options +FollowSymLinks +ExecCGI
 
 RewriteEngine On
-RewriteCond %{REQUEST_URI}  !(\.png|\.jpg|\.gif|\.jpeg|\.bmp)$
 RewriteRule ^api/.*  ./api.php [QSA]
 RewriteRule ^newapi/.*  ./newapi.php [QSA]

--- a/api.php
+++ b/api.php
@@ -74,8 +74,8 @@
 	$topLevelRequest = $param[0];
 			
 	//Base app query
-	$baseAppQuery = 'SELECT app.guid, app.name, app.publisher, app.version, app.description, app.category, app.subcategory, app.rating, app.downloads, user.nick AS publisher,
-					appver.number AS version, maincat.name AS category, subcat.name AS subcategory, appver.largeIcon AS largeicon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5 FROM apps app
+	$baseAppQuery = 'SELECT app.guid, app.name, app.description, app.rating, app.downloads,
+					user.nick AS publisher, appver.number AS version, maincat.name AS category, subcat.name AS subcategory, appver.largeIcon AS largeicon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5 FROM apps app
 					LEFT JOIN users user ON user.userId = app.publisher
 					LEFT JOIN appversions appver ON appver.versionId = app.version
 					LEFT JOIN categories maincat ON maincat.categoryId = app.category

--- a/apps/.htaccess
+++ b/apps/.htaccess
@@ -1,0 +1,3 @@
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule (.*)  ./app.php [QSA]

--- a/apps/.htaccess
+++ b/apps/.htaccess
@@ -1,3 +1,4 @@
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule (.*)  ./app.php [QSA]
+RewriteRule !^view/.*  ./index.php [QSA]
+RewriteRule ^view/.*  ./app.php [QSA]

--- a/apps/app.php
+++ b/apps/app.php
@@ -5,8 +5,7 @@
 	
 	//TODO: Add more information (screenshots, reviews, etc.)
 	
-	$title = 'Browse Apps';
-	require_once('../common/uiheader.php');
+	require_once('../common/functions.php');
 	
 	$requestUri = strtok(getenv('REQUEST_URI'), '?');
 	$appGuid = rtrim(substr($requestUri, strlen('/apps/')), '/');
@@ -22,19 +21,26 @@
 	
 	printAndExitIfTrue(count($matchingApps) !== 1, 'Invalid app GUID.');
 	$app = $matchingApps[0];
+	
+	$title = $app['name'];
+	require_once('../common/uiheader.php');
 ?>
 
 	<h1 class="text-center"><?php echo $app['name']; ?></h1>
 	<h3 class="text-center">
 		<span id="maincat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb"<?php if ($app['subcategory'] !== null) echo ' itemref="subcat"'; ?>>
-			<span itemprop="title"><?php echo $app['category']; ?></span>
+			<a itemprop="url" href="/apps/<?php echo $app['category']; ?>">
+				<span itemprop="title"><?php echo $app['category']; ?></span>
+			</a>
 		</span>
 <?php
 	if ($app['subcategory'] !== null) {
 		echo
 		'<span class="glyphicon glyphicon-arrow-right" style="font-size: 20px;"></span>
 		<span id="subcat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" itemprop="child">
-			<span itemprop="title">' . $app['subcategory'] . '</span>
+			<a itemprop="url" href="/apps/' . $app['category'] . '/' . $app['subcategory'] . '">
+				<span itemprop="title">' . $app['subcategory'] . '</span>
+			</a>
 		</span>';
 	}
 ?>

--- a/apps/app.php
+++ b/apps/app.php
@@ -76,7 +76,6 @@
 			
 <?php
 	if ($app['screenshots'] !== null) {
-		$app['screenshots'] = '/vendor/test.png,/vendor/test.png,/vendor/test.png,/vendor/test.png,/vendor/test.png';
 		$screenshots = explode(',', $app['screenshots']);
 		$screenshotRows = array_chunk($screenshots, 2);
 		foreach ($screenshotRows as $screenshotRow) {

--- a/apps/app.php
+++ b/apps/app.php
@@ -25,7 +25,21 @@
 ?>
 
 	<h1 class="text-center"><?php echo $app['name']; ?></h1>
-	<h3 class="text-center"><?php echo $app['category']; if ($app['subcategory'] !== null) { echo ' <span class="glyphicon glyphicon-arrow-right" style="font-size: 20px;"></span> ' . $app['subcategory']; } ?></h1>
+	<h3 class="text-center">
+		<span id="maincat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb"<?php if ($app['subcategory'] !== null) echo ' itemref="subcat"'; ?>>
+			<span itemprop="title"><?php echo $app['category']; ?></span>
+		</span>
+<?php
+	if ($app['subcategory'] !== null) {
+		echo
+		'<span class="glyphicon glyphicon-arrow-right" style="font-size: 20px;"></span>
+		<span id="subcat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" itemprop="child">
+			<span itemprop="title">' . $app['subcategory'] . '</span>
+		</span>';
+	}
+?>
+
+	</h3>
 	<br />
 	<div id="appcontainer">
 		<div class="well clearfix">

--- a/apps/app.php
+++ b/apps/app.php
@@ -78,18 +78,16 @@
 	if ($app['screenshots'] !== null) {
 		$screenshots = explode(',', $app['screenshots']);
 		$screenshotRows = array_chunk($screenshots, 2);
+		
 		foreach ($screenshotRows as $screenshotRow) {
-			echo '<div class="row">
-			';
+			echo '<div class="row">';
 			foreach ($screenshotRow as $screenshot) {
 				echo
 				'<div class="col-md-' . (12 / count($screenshotRow)) . '" style="text-align: center;">
 					<img class="app-screenshot" src="' . $screenshot . '" />
-				</div>
-				';
+				</div>';
 			}
-			echo '</div>
-			';
+			echo '</div>';
 		}
 	}
 ?>

--- a/apps/app.php
+++ b/apps/app.php
@@ -63,7 +63,7 @@
 				</div>
 			</div>
 			<div class="app-vertical-center-outer pull-right btn-toolbar">
-				<div class="btn-toolbar app-vertical-center-inner">
+				<div class="app-vertical-center-inner">
 					<button class="btn btn-default disabled"><span class="glyphicon glyphicon-download"></span> <?php echo $app['downloads']; ?> unique downloads</button>
 				</div>
 			</div>
@@ -83,7 +83,7 @@
 			echo '<div class="row">';
 			foreach ($screenshotRow as $screenshot) {
 				echo
-				'<div class="col-md-' . (12 / count($screenshotRow)) . '" style="text-align: center;">
+				'<div class="col-md-' . (12 / count($screenshotRow)) . ' app-screenshot-vertical-center" style="text-align: center;">
 					<img class="app-screenshot" src="' . $screenshot . '" />
 				</div>';
 			}

--- a/apps/app.php
+++ b/apps/app.php
@@ -11,8 +11,8 @@
 	$appGuid = rtrim(substr($requestUri, strlen('/apps/')), '/');
 	
 	$mysqlConn = connectToDatabase();
-	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.publisher, app.description, app.downloads, app.publishstate, app.failpublishmessage, user.nick AS publisher,
-														appver.number AS version, appver.largeIcon, maincat.name AS category, subcat.name AS subcategory FROM apps app
+	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.publisher, app.description, app.downloads, app.publishstate, app.failpublishmessage, app.screenshot1, app.screenshot2, app.screenshot3
+														user.nick AS publisher, appver.number AS version, appver.largeIcon, maincat.name AS category, subcat.name AS subcategory FROM apps app
 														LEFT JOIN users user ON user.userId = app.publisher
 														LEFT JOIN appversions appver ON appver.versionId = app.version
 														LEFT JOIN categories maincat ON maincat.categoryId = app.category

--- a/apps/app.php
+++ b/apps/app.php
@@ -31,7 +31,7 @@
 	<h1 class="text-center"><?php echo $app['name']; ?></h1>
 	<h3 class="text-center">
 		<span id="maincat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb"<?php if ($app['subcategory'] !== null) echo ' itemref="subcat"'; ?>>
-			<a itemprop="url" href="/apps/<?php echo $app['category']; ?>">
+			<a itemprop="url" href="/apps/<?php echo $app['category']; ?>" style="color: black;">
 				<span itemprop="title"><?php echo $app['category']; ?></span>
 			</a>
 		</span>
@@ -40,7 +40,7 @@
 		echo
 		'<span class="glyphicon glyphicon-arrow-right" style="font-size: 20px;"></span>
 		<span id="subcat" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" itemprop="child">
-			<a itemprop="url" href="/apps/' . $app['category'] . '/' . $app['subcategory'] . '">
+			<a itemprop="url" href="/apps/' . $app['category'] . '/' . $app['subcategory'] . '" style="color: black;">
 				<span itemprop="title">' . $app['subcategory'] . '</span>
 			</a>
 		</span>';

--- a/apps/app.php
+++ b/apps/app.php
@@ -1,0 +1,59 @@
+<?php
+	/*
+		DownloadMii App Information Page
+	*/
+	
+	//TODO: Add more information (screenshots, reviews, etc.)
+	
+	$title = 'Browse Apps';
+	require_once('../common/uiheader.php');
+	
+	$requestUri = strtok(getenv('REQUEST_URI'), '?');
+	$appGuid = rtrim(substr($requestUri, strlen('/apps/')), '/');
+	
+	$mysqlConn = connectToDatabase();
+	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.publisher, app.description, app.downloads, app.publishstate, app.failpublishmessage, user.nick AS publisher,
+														appver.number AS version, appver.largeIcon, maincat.name AS category, subcat.name AS subcategory FROM apps app
+														LEFT JOIN users user ON user.userId = app.publisher
+														LEFT JOIN appversions appver ON appver.versionId = app.version
+														LEFT JOIN categories maincat ON maincat.categoryId = app.category
+														LEFT JOIN categories subcat ON subcat.categoryId = app.subcategory
+														WHERE app.guid = ?', 's', [$appGuid]);
+	
+	printAndExitIfTrue(count($matchingApps) !== 1, 'Invalid app GUID.');
+	$app = $matchingApps[0];
+?>
+
+	<h1 class="text-center"><?php echo $app['name']; ?></h1>
+	<h3 class="text-center"><?php echo $app['category']; if ($app['subcategory'] !== null) { echo ' <span class="glyphicon glyphicon-arrow-right" style="font-size: 20px;"></span> ' . $app['subcategory']; } ?></h1>
+	<br />
+	<div id="appcontainer">
+		<div class="well clearfix">
+			<div class="app-vertical-center-outer pull-left">
+				<img class="app-icon" src="<?php if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
+				<div class="pull-right">
+					<h4 class="app-vertical-center-inner">
+<?php
+	echo '<span itemprop="name">' . escapeHTMLChars($app['name']) . '</span> <span itemprop="softwareVersion">' . escapeHTMLChars($app['version']) . '</span> by <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization" style="font-style: italic;">' . $app['publisher'] . '</span>';
+?>
+
+					</h4>
+				</div>
+			</div>
+			<div class="app-vertical-center-outer pull-right btn-toolbar">
+				<div class="btn-toolbar app-vertical-center-inner">
+					<button class="btn btn-default disabled"><span class="glyphicon glyphicon-download"></span> <?php echo $app['downloads']; ?> unique downloads</button>
+				</div>
+			</div>
+			<div class="clear-float" style="padding-top: 8px">
+<?php
+	echo escapeHTMLChars($app['description']);
+?>
+
+			</div>
+		</div>
+
+	</div>
+<?php		
+	require_once('../common/uifooter.php');
+?>

--- a/apps/app.php
+++ b/apps/app.php
@@ -8,7 +8,7 @@
 	require_once('../common/functions.php');
 	
 	$requestUri = strtok(getenv('REQUEST_URI'), '?');
-	$appGuid = rtrim(substr($requestUri, strlen('/apps/')), '/');
+	$appGuid = rtrim(substr($requestUri, strlen('/apps/view/')), '/');
 	
 	$mysqlConn = connectToDatabase();
 	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.description, app.downloads, app.publishstate, app.failpublishmessage,

--- a/apps/index.php
+++ b/apps/index.php
@@ -3,11 +3,13 @@
 		DownloadMii App List Page (all published apps)
 	*/
 	
+	//TODO: Clean code...
+	
 	$title = 'Browse Apps';
 	require_once('../common/uiheader.php');
 	
 	$mysqlConn = connectToDatabase();
-	$allApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.publisher, app.description, app.downloads, app.publishstate, app.failpublishmessage, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
+	$allApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.publisher, app.description, app.downloads, app.publishstate, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
 													LEFT JOIN users user ON user.userId = app.publisher
 													LEFT JOIN appversions appver ON appver.versionId = app.version
 													WHERE app.publishstate = 1 ORDER BY appver.versionId DESC');
@@ -26,7 +28,7 @@
 	
 	<div id="appcontainer">
 <?php
-	foreach ($allApps as $app) { //ToDo: update based on search via Ajax
+	foreach ($allApps as $app) {
 ?>
 
 		<div class="well clearfix">
@@ -34,10 +36,12 @@
 				<img class="app-icon" src="<?php if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
 				<div class="pull-right">
 					<h4 class="app-vertical-center-inner">
+						<a href="/apps/<?php echo $app['guid'] ?>" style="color: black;">
 <?php
-			echo escapeHTMLChars($app['name'] . ' ' . $app['version']) . ' by <span style="font-style: italic;">' . $app['publisher'] . '</span>';
+		echo '<span itemprop="name">' . escapeHTMLChars($app['name']) . '</span> <span itemprop="softwareVersion">' . escapeHTMLChars($app['version']) . '</span> by <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization" style="font-style: italic;">' . $app['publisher'] . '</span>';
 ?>
 
+						</a>
 					</h4>
 				</div>
 			</div>
@@ -48,7 +52,7 @@
 			</div>
 			<div class="clear-float" style="padding-top: 8px">
 <?php
-			echo escapeHTMLChars($app['description']);
+		echo escapeHTMLChars($app['description']);
 ?>
 
 			</div>
@@ -68,8 +72,10 @@
 											'<div itemscope itemtype="http://schema.org/SoftwareApplication" class="app-vertical-center-outer pull-left">' +
 												'<img itemprop="image" class="app-icon" src="' + (element.largeicon !== '' ? element.largeicon : '/img/no_icon.png') + '" />' +
 												'<div class="pull-right">' +
-													'<h4 class="app-vertical-center-inner"><span itemprop="name">' +
-														element.name + '</span> <span itemprop="softwareVersion">' + element.version + '</span> by <span itemprop="publisher" itemscope itemtype="http://schema.org/Organization" style="font-style: italic;">' + element.publisher + '</span>' +
+													'<h4 class="app-vertical-center-inner">' +
+														'<a href="/apps/' + element.guid + '" style="color: black;">' +
+															element.name + ' ' + element.version + ' by <span style="font-style: italic;">' + element.publisher + '</span>' +
+														'</a>' +
 													'</h4>' +
 												'</div>' +
 											'</div>' +
@@ -110,6 +116,12 @@
 		$('#resetbutton').on('click', function() {
 			printDefaultApps();
 			$('#searchtext').val('');
+		});
+		
+		$('#searchtext').on('keypress', function(e) {
+			if (e.which === 13) {
+				$('#searchbutton').click();
+			}
 		});
 		
 		var params = getURLParams();

--- a/apps/index.php
+++ b/apps/index.php
@@ -9,7 +9,7 @@
 	require_once('../common/uiheader.php');
 	
 	$mysqlConn = connectToDatabase();
-	$allApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.publisher, app.description, app.downloads, app.publishstate, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
+	$allApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.description, app.downloads, app.publishstate, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
 													LEFT JOIN users user ON user.userId = app.publisher
 													LEFT JOIN appversions appver ON appver.versionId = app.version
 													WHERE app.publishstate = 1 ORDER BY appver.versionId DESC');

--- a/common/functions.php
+++ b/common/functions.php
@@ -190,7 +190,7 @@
 		$stmt = $conn->prepare($sql);
 		printAndExitIfTrue(!$stmt, 'Error preparing database query.');
 		
-		if (isset($bindParamTypes, $bindParamVarsArr) && !empty($bindParamTypes)) {
+		if (isset($bindParamTypes, $bindParamVarsArr) && !empty($bindParamTypes) && !empty($bindParamVarsArr)) {
 			$callUserArgs = $bindParamVarsArr;
 			array_unshift($callUserArgs, $bindParamTypes);
 			

--- a/common/meta.php
+++ b/common/meta.php
@@ -1,99 +1,99 @@
 <!-- SEO -->
-<meta name="description" content="DownloadMii is an online marketplace for homebrew applications. It's 100% free of charge!" />
-<meta name="keywords" content="DownloadMii, Nintendo 3DS Homebrew, Homebrew Browser, 3ds, filfat, Wii U Homebrew" />
-<meta name="author" CONTENT="DownloadMii Team">
-<meta name="google-site-verification" content="oUzBcLbkKoA1gb5G8ZWgzzLR_LmIMFa0F8gsCH39LRc" />
-<meta name="msvalidate.01" content="5F5165B227A54717CAF54D2E5DB6DE79" />
-<link rel="alternate" href="downloadmii.com" hreflang="en-us">
-<link rel="alternate" href="downloadmii.com" hreflang="en">
-<meta charset="utf-8" />
-<script type="application/ld+json">
-	{
-	  "@context": "http://schema.org",
-	  "@type": "WebSite",
-	  "url": "https://www.downloadmii.com/",
-	  "potentialAction": {
-		"@type": "SearchAction",
-		"target": "https://www.downloadmii.com/apps?find={search_term_string}",
-		"query-input": "required name=search_term_string"
-	  }
-	}
-</script>
+		<meta name="description" content="DownloadMii is an online marketplace for homebrew applications. It's 100% free of charge!" />
+		<meta name="keywords" content="DownloadMii, Nintendo 3DS Homebrew, Homebrew Browser, 3ds, filfat, Wii U Homebrew" />
+		<meta name="author" CONTENT="DownloadMii Team">
+		<meta name="google-site-verification" content="oUzBcLbkKoA1gb5G8ZWgzzLR_LmIMFa0F8gsCH39LRc" />
+		<meta name="msvalidate.01" content="5F5165B227A54717CAF54D2E5DB6DE79" />
+		<link rel="alternate" href="downloadmii.com" hreflang="en-us">
+		<link rel="alternate" href="downloadmii.com" hreflang="en">
+		<meta charset="utf-8" />
+		<script type="application/ld+json">
+			{
+			  "@context": "http://schema.org",
+			  "@type": "WebSite",
+			  "url": "https://www.downloadmii.com/",
+			  "potentialAction": {
+				"@type": "SearchAction",
+				"target": "https://www.downloadmii.com/apps?find={search_term_string}",
+				"query-input": "required name=search_term_string"
+			  }
+			}
+		</script>
 
-<!-- METADATA -->
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<link rel="shortcut icon" type="image/ico" href="https://www.downloadmii.com/favicon.ico" />
+		<!-- METADATA -->
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<link rel="shortcut icon" type="image/ico" href="https://www.downloadmii.com/favicon.ico" />
 
-<!-- STYLESHEETS -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-<link href="/css/mainStruct.css" rel="stylesheet"/>
+		<!-- STYLESHEETS -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+		<link href="/css/mainStruct.css" rel="stylesheet"/>
 
-<!-- IN CASE OF OLD WEBBROWSER -->
-<script> 
-var $buoop = {c:2}; 
-function $buo_f(){ 
- var e = document.createElement("script"); 
- e.src = "//browser-update.org/update.js"; 
- document.body.appendChild(e);
-};
-try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
-catch(e){window.attachEvent("onload", $buo_f)}
-</script> 
+		<!-- IN CASE OF OLD WEBBROWSER -->
+		<script> 
+		var $buoop = {c:2}; 
+		function $buo_f(){ 
+		 var e = document.createElement("script"); 
+		 e.src = "//browser-update.org/update.js"; 
+		 document.body.appendChild(e);
+		};
+		try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
+		catch(e){window.attachEvent("onload", $buo_f)}
+		</script> 
 
-<!-- PLATFORM SPECIFIC -->
-<!-- MICROSOFT -->
-<meta name="application-name" content="DownloadMii" />
-<link rel="dns-prefetch" href="http://filfatstudios.com"/>
-<link rel="prerender" href="https://www.downloadmii.com/apps/" />
+		<!-- PLATFORM SPECIFIC -->
+		<!-- MICROSOFT -->
+		<meta name="application-name" content="DownloadMii" />
+		<link rel="dns-prefetch" href="http://filfatstudios.com"/>
+		<link rel="prerender" href="https://www.downloadmii.com/apps/" />
 
-<!-- IE SITE PIN -->
-<meta name="msapplication-starturl" content="https://www.downloadmii.com" />
-<meta name="msapplication-navbutton-color" content="#25A4D6" />
-<meta name="msapplication-window" content="width=1024;height=768" />
-<meta name="msapplication-tooltip" content="Visit DownloadMii" />
-<meta content="name=Home;action-uri=./;icon-uri=./favicon.ico" name="msapplication-task" />
-<meta content="name=User CP;action-uri=./secure/myapps.php;icon-uri=./favicon.ico" name="msapplication-task" />
+		<!-- IE SITE PIN -->
+		<meta name="msapplication-starturl" content="https://www.downloadmii.com" />
+		<meta name="msapplication-navbutton-color" content="#25A4D6" />
+		<meta name="msapplication-window" content="width=1024;height=768" />
+		<meta name="msapplication-tooltip" content="Visit DownloadMii" />
+		<meta content="name=Home;action-uri=./;icon-uri=./favicon.ico" name="msapplication-task" />
+		<meta content="name=User CP;action-uri=./secure/myapps.php;icon-uri=./favicon.ico" name="msapplication-task" />
 
 
-<!-- LIVE TILE -->
-<meta name="msapplication-TileColor" content="#25A4D6" />
-<meta name="msapplication-square70x70logo" content="/img/LiveTiles/smalltile.png" />
-<meta name="msapplication-square150x150logo" content="/img/LiveTiles/mediumtile.png" />
-<meta name="msapplication-wide310x150logo" content="/img/LiveTiles/widetile.png" />
-<meta name="msapplication-square310x310logo" content="/img/LiveTiles/largetile.png" />
+		<!-- LIVE TILE -->
+		<meta name="msapplication-TileColor" content="#25A4D6" />
+		<meta name="msapplication-square70x70logo" content="/img/LiveTiles/smalltile.png" />
+		<meta name="msapplication-square150x150logo" content="/img/LiveTiles/mediumtile.png" />
+		<meta name="msapplication-wide310x150logo" content="/img/LiveTiles/widetile.png" />
+		<meta name="msapplication-square310x310logo" content="/img/LiveTiles/largetile.png" />
 
-<!-- APPLE -->
-<link rel="apple-touch-icon" href="/img/Apple/touch-icon-iphone.png" /> 
-<link rel="apple-touch-icon" sizes="76x76" href="/img/Apple/touch-icon-ipad.png" /> 
-<link rel="apple-touch-icon" sizes="120x120" href="/img/Apple/touch-icon-iphone-retina.png" />
-<link rel="apple-touch-icon" sizes="152x152" href="/img/Apple/touch-icon-ipad-retina.png" />
-<link rel="apple-touch-startup-image" href="/img/Apple/startup.png" />
-<meta name="apple-mobile-web-app-status-bar-style" content="white" />
-<meta name="apple-mobile-web-app-capable" content="yes" />
-<meta name="apple-mobile-web-app-title" content="DownloadMii"/>
-<link rel="apple-touch-startup-image" href="/img/Apple/startup.png">
+		<!-- APPLE -->
+		<link rel="apple-touch-icon" href="/img/Apple/touch-icon-iphone.png" /> 
+		<link rel="apple-touch-icon" sizes="76x76" href="/img/Apple/touch-icon-ipad.png" /> 
+		<link rel="apple-touch-icon" sizes="120x120" href="/img/Apple/touch-icon-iphone-retina.png" />
+		<link rel="apple-touch-icon" sizes="152x152" href="/img/Apple/touch-icon-ipad-retina.png" />
+		<link rel="apple-touch-startup-image" href="/img/Apple/startup.png" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="white" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-title" content="DownloadMii"/>
+		<link rel="apple-touch-startup-image" href="/img/Apple/startup.png">
 
-<!-- GOOGLE -->
-<link rel="icon" sizes="128x128" href="/img/Apple/touch-icon-iphone-retina.png" />
-<meta name="theme-color" content="#25A4D6">
-<meta name="mobile-web-app-capable" content="yes">
-<link rel="prerender" href="https://www.downloadmii.com/apps/">
+		<!-- GOOGLE -->
+		<link rel="icon" sizes="128x128" href="/img/Apple/touch-icon-iphone-retina.png" />
+		<meta name="theme-color" content="#25A4D6">
+		<meta name="mobile-web-app-capable" content="yes">
+		<link rel="prerender" href="https://www.downloadmii.com/apps/">
 
-<!-- SOCIAL MEDIA -->
-<meta property="og:title" content="DownloadMii - Download homebrew directly to your 3DS"/>
-<meta property="og:type" content="website"/>
-<meta property="og:image" content="http://www.downloadmii.com/img/livetiles/largetile.png"/>
-<meta property="og:url" content="https://www.downloadmii.com"/>
-<meta name="twitter:title" content="DownloadMii">
+		<!-- SOCIAL MEDIA -->
+		<meta property="og:title" content="DownloadMii - Download homebrew directly to your 3DS"/>
+		<meta property="og:type" content="website"/>
+		<meta property="og:image" content="http://www.downloadmii.com/img/livetiles/largetile.png"/>
+		<meta property="og:url" content="https://www.downloadmii.com"/>
+		<meta name="twitter:title" content="DownloadMii">
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+		<script>
+		  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+		  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+		  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+		  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-36429627-11', 'auto');
-  ga('send', 'pageview');
+		  ga('create', 'UA-36429627-11', 'auto');
+		  ga('send', 'pageview');
 
-</script>
+		</script>

--- a/common/uiheader.php
+++ b/common/uiheader.php
@@ -6,7 +6,7 @@
 	
 	require_once($_SERVER['DOCUMENT_ROOT'] . '\common\user.php');
 	header('Cache-Control: private');
-?>
+?><!DOCTYPE html>
 <html>
 	<head>
 		<?php

--- a/common/uiheader.php
+++ b/common/uiheader.php
@@ -1,7 +1,7 @@
 <?php
 	/*
 		DownloadMii Page Header
-		This file automatically includes functions.php and user.php, which includes functions.php
+		This file automatically includes user.php, which includes functions.php
 	*/
 	
 	require_once($_SERVER['DOCUMENT_ROOT'] . '\common\user.php');
@@ -47,7 +47,7 @@
 			
 			.app-screenshot {
 				width: 400px;
-				height: 240px;
+				height: auto;
 				margin-top: 32px;
 			}
 			
@@ -60,6 +60,16 @@
 				height: 48px;
 				display: table-cell;
 				vertical-align: middle;
+			}
+			
+			.app-screenshot-vertical-center {
+				float: none;
+				display: inline-block;
+				vertical-align: middle;
+			}
+			
+			.app-vertical-center-inner {
+				height: 48px;
 			}
 			
 			.clear-float {

--- a/common/uiheader.php
+++ b/common/uiheader.php
@@ -21,7 +21,7 @@
 			#maincontent {
 				margin-left: auto;
 				margin-right: auto;
-				max-width: 1200px;
+				max-width: 1060px;
 			}
 			
 			.downloadmii {
@@ -43,6 +43,12 @@
 				width: 48px;
 				height: 48px;
 				margin-right: 12px;
+			}
+			
+			.app-screenshot {
+				width: 400px;
+				height: 240px;
+				margin-top: 32px;
 			}
 			
 			.app-vertical-center-outer {

--- a/config.template.php
+++ b/config.template.php
@@ -11,6 +11,7 @@
 		'azure_container_smdh' => '',
 		'azure_container_appdata' => '',
 		'azure_container_largeicon' => '',
+		'azure_container_screenshots' => '',
 		
 		//MySQL
 		'mysql_host' => '',

--- a/config.template.php
+++ b/config.template.php
@@ -24,6 +24,7 @@
 		'apikey_recaptcha_secret' => '',
 		
 		//DownloadMii
-		'downloadmii_app_guid' => ''
+		'downloadmii_app_guid' => '',
+		'downloadmii_max_screenshots' => 4
 	);
 ?>

--- a/doc/DB/dwnmii DB doc.md
+++ b/doc/DB/dwnmii DB doc.md
@@ -25,6 +25,11 @@ Column|Description|
 `number` | Version number, ex: '1.0.0.0' |
 `3dsx` | 3dsx url |
 `smdh` | smdh url |
+`appdata` | appdata url |
+`largeIcon` | large icon url |
+`3dsx_md5` | 3dsx md5 |
+`smdh_md5` | smdh md5 |
+`appdata_md5` | appdata md5 |
 
 ##Apps
 Column|Description|
@@ -40,6 +45,9 @@ Column|Description|
 `downloads` | Download count |
 `publishstate` | Publish state: 0 - pending approval, 1 - published, 2 - rejected, 3 - hidden |
 `failpublishmessage` | If app rejected, reason why |
+`screenshot1` | Screenshot 1 url |
+`screenshot2` | Screenshot 2 url |
+`screenshot3` | Screenshot 3 url |
 
 ##Ratings
 Column|Description|

--- a/doc/DB/dwnmii DB doc.md
+++ b/doc/DB/dwnmii DB doc.md
@@ -46,6 +46,14 @@ Column|Description|
 `publishstate` | Publish state: 0 - pending approval, 1 - published, 2 - rejected, 3 - hidden |
 `failpublishmessage` | If app rejected, reason why |
 
+##Screenshots
+Column|Description|
+---|:---|
+`ratingId` | Id of the sceenshot |
+`appGuid` | id of the app the screenshot belongs to, reference into apps table |
+`imageIndex` | Image index for app (starts at 1) |
+`url` | Screenshot url |
+
 ##Ratings
 Column|Description|
 ---|:---|

--- a/doc/DB/dwnmii DB doc.md
+++ b/doc/DB/dwnmii DB doc.md
@@ -45,9 +45,6 @@ Column|Description|
 `downloads` | Download count |
 `publishstate` | Publish state: 0 - pending approval, 1 - published, 2 - rejected, 3 - hidden |
 `failpublishmessage` | If app rejected, reason why |
-`screenshot1` | Screenshot 1 url |
-`screenshot2` | Screenshot 2 url |
-`screenshot3` | Screenshot 3 url |
 
 ##Ratings
 Column|Description|

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -47,7 +47,7 @@ CREATE TABLE apps(
 	FOREIGN KEY (publisher) REFERENCES users(userId),
 	FOREIGN KEY (version) REFERENCES appversions(versionId),
 	FOREIGN KEY (category) REFERENCES categories(categoryId),
-	FOREIGN KEY (subcategory) REFERENCES categories(categoryId),
+	FOREIGN KEY (subcategory) REFERENCES categories(categoryId)
 );
 
 CREATE TABLE screenshots(

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -56,7 +56,7 @@ CREATE TABLE screenshots(
 	imageIndex TINYINT NOT NULL,
 	url VARCHAR(255) NOT NULL,
 	
-	CONSTRAINT uq_guid_index UNIQUE(appGuid, imageIndex),
+	UNIQUE KEY uq_guid_index(appGuid, imageIndex),
 	
 	FOREIGN KEY (appGuid) REFERENCES apps(guid)
 );

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -52,7 +52,7 @@ CREATE TABLE apps(
 
 CREATE TABLE screenshots(
 	screenshotId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	appGuid INT NOT NULL,
+	appGuid CHAR(36) NOT NULL,
 	url VARCHAR(255) NOT NULL,
 	
 	FOREIGN KEY (appGuid) REFERENCES apps(guid)

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -40,6 +40,9 @@ CREATE TABLE apps(
 	downloads INT NOT NULL DEFAULT 0,
 	publishstate TINYINT NOT NULL DEFAULT 0,
 	failpublishmessage VARCHAR(24) NULL,
+	screenshot1 VARCHAR(255) NULL,
+	screenshot2 VARCHAR(255) NULL,
+	screenshot3 VARCHAR(255) NULL,
 	
 	FULLTEXT(name),
 	FULLTEXT(description),

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -40,9 +40,7 @@ CREATE TABLE apps(
 	downloads INT NOT NULL DEFAULT 0,
 	publishstate TINYINT NOT NULL DEFAULT 0,
 	failpublishmessage VARCHAR(24) NULL,
-	screenshot1 VARCHAR(255) NULL,
-	screenshot2 VARCHAR(255) NULL,
-	screenshot3 VARCHAR(255) NULL,
+	screenshotCollection INT NULL,
 	
 	FULLTEXT(name),
 	FULLTEXT(description),
@@ -50,7 +48,23 @@ CREATE TABLE apps(
 	FOREIGN KEY (publisher) REFERENCES users(userId),
 	FOREIGN KEY (version) REFERENCES appversions(versionId),
 	FOREIGN KEY (category) REFERENCES categories(categoryId),
-	FOREIGN KEY (subcategory) REFERENCES categories(categoryId)
+	FOREIGN KEY (subcategory) REFERENCES categories(categoryId),
+	FOREIGN KEY (screenshotCollection) REFERENCES screenshotcollections(collectionId)
+);
+
+CREATE TABLE screenshotcollections(
+	collectionId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+	appGuid CHAR(36) NOT NULL,
+	
+	FOREIGN KEY (appGuid) REFERENCES apps(guid)
+);
+
+CREATE TABLE screenshots(
+	screenshotId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+	collection INT NOT NULL,
+	url VARCHAR(255) NOT NULL,
+	
+	FOREIGN KEY (collection) REFERENCES screenshotcollections(collectionId)
 );
 
 CREATE TABLE ratings(

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -40,7 +40,6 @@ CREATE TABLE apps(
 	downloads INT NOT NULL DEFAULT 0,
 	publishstate TINYINT NOT NULL DEFAULT 0,
 	failpublishmessage VARCHAR(24) NULL,
-	screenshotCollection INT NULL,
 	
 	FULLTEXT(name),
 	FULLTEXT(description),
@@ -49,22 +48,14 @@ CREATE TABLE apps(
 	FOREIGN KEY (version) REFERENCES appversions(versionId),
 	FOREIGN KEY (category) REFERENCES categories(categoryId),
 	FOREIGN KEY (subcategory) REFERENCES categories(categoryId),
-	FOREIGN KEY (screenshotCollection) REFERENCES screenshotcollections(collectionId)
-);
-
-CREATE TABLE screenshotcollections(
-	collectionId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	appGuid CHAR(36) NOT NULL,
-	
-	FOREIGN KEY (appGuid) REFERENCES apps(guid)
 );
 
 CREATE TABLE screenshots(
 	screenshotId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
-	collection INT NOT NULL,
+	appGuid INT NOT NULL,
 	url VARCHAR(255) NOT NULL,
 	
-	FOREIGN KEY (collection) REFERENCES screenshotcollections(collectionId)
+	FOREIGN KEY (appGuid) REFERENCES apps(guid)
 );
 
 CREATE TABLE ratings(

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -53,7 +53,10 @@ CREATE TABLE apps(
 CREATE TABLE screenshots(
 	screenshotId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
 	appGuid CHAR(36) NOT NULL,
+	imageIndex TINYINT NOT NULL,
 	url VARCHAR(255) NOT NULL,
+	
+	PRIMARY KEY(appGuid, imageIndex);
 	
 	FOREIGN KEY (appGuid) REFERENCES apps(guid)
 );

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -56,7 +56,7 @@ CREATE TABLE screenshots(
 	imageIndex TINYINT NOT NULL,
 	url VARCHAR(255) NOT NULL,
 	
-	PRIMARY KEY(appGuid, imageIndex);
+	CONSTRAINT uq_guid_index UNIQUE(appGuid, imageIndex),
 	
 	FOREIGN KEY (appGuid) REFERENCES apps(guid)
 );

--- a/newApi.php
+++ b/newApi.php
@@ -63,13 +63,15 @@
 	$topLevelRequest = $param[0];
 			
 	//Base app query
-	$baseAppQuery = 'SELECT app.guid, app.name, app.publisher, app.version, app.description, app.category, app.subcategory, app.rating, app.downloads, user.nick AS publisher,
-					appver.number AS version, maincat.name AS category, subcat.name AS subcategory, appver.largeIcon AS largeicon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5 FROM apps app
+	$baseAppQuery = 'SELECT app.guid, app.name, app.description, app.rating, app.downloads,
+					user.nick AS publisher, appver.number AS version, maincat.name AS category, subcat.name AS subcategory, appver.largeIcon AS largeicon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5, group_concat(scr.url) AS screenshots FROM apps app
 					LEFT JOIN users user ON user.userId = app.publisher
 					LEFT JOIN appversions appver ON appver.versionId = app.version
 					LEFT JOIN categories maincat ON maincat.categoryId = app.category
 					LEFT JOIN categories subcat ON subcat.categoryId = app.subcategory
-					WHERE app.publishstate = 1';
+					LEFT JOIN screenshots scr ON scr.appGuid = app.guid
+					WHERE app.publishstate = 1
+					GROUP BY app.guid';
 	
 	switch (strtolower($topLevelRequest)) {
 		case 'apps':

--- a/secure/action_publish.php
+++ b/secure/action_publish.php
@@ -10,6 +10,26 @@
 	
 	use WindowsAzure\Common\ServicesBuilder;
 	
+	class blob {
+		public $md5;
+		public $name;
+		public $url;
+		public $fileHandle;
+		
+		public function upload($blobRestProxy, $container, $filePath) {
+			$this->md5 = md5_file($filePath); //Get file hash
+			$this->name = generateRandomString(); //Generate file blob name
+			$this->url = 'https://' . getConfigValue('azure_storage_account') . '.blob.core.windows.net/' . $container . '/' . $this->name; //Get Azure blob URL
+			
+			$this->fileHandle = fopen($filePath, 'r');
+			$blobRestProxy->createBlockBlob($container, $this->name, $fileHandle); //Upload blob to Azure Blob Service
+		}
+		
+		public function closeFileHandle() {
+			fclose($this->fileHandle);
+		}
+	}
+	
 	if (isset($_POST['guidid'], $_SESSION['publish_app_guid' . $_POST['guidid']])) {
 		$guid = $_SESSION['publish_app_guid' . $_POST['guidid']]; //Get GUID
 		
@@ -50,13 +70,13 @@
 				$isDeveloper = $_SESSION['user_role'] > 1;
 				$updatingApp = isset($_SESSION['user_app_version' . $guid]);
 				
+				$updatingAppData = is_uploaded_file($appDataPath);
 				if (!$updatingApp) {
 					throwExceptionIfTrue(!is_uploaded_file($app3dsxPath) || !is_uploaded_file($appSmdhPath), 'Please upload the required files.');
 				}
 				else {
 					$updating3dsx = is_uploaded_file($app3dsxPath);
 					$updatingSmdh = is_uploaded_file($appSmdhPath);
-					$updatingAppData = is_uploaded_file($appDataPath);
 					
 					//Check that if 3dsx/appdata is changed, the version also is
 					throwExceptionIfTrue($_SESSION['user_app_version' . $guid] === $_POST['version'] && ($updating3dsx || $updatingAppData), 'Please also update the version number when uploading a new 3dsx/appdata file.');
@@ -80,52 +100,41 @@
 					$blobRestProxy = ServicesBuilder::getInstance()->createBlobService(getConfigValue('azure_connection_string'));
 				}
 				
+				$app3dsxBlob = new blob();
 				if (!$updatingApp || $updating3dsx) {
-					$app3dsxMD5 = md5_file($app3dsxPath); //Get file hash
-					$app3dsxBlobName = generateRandomString(); //Generate file blob name
-					$app3dsxBlobURL = 'https://' . getConfigValue('azure_storage_account') . '.blob.core.windows.net/' . getConfigValue('azure_container_3dsx') . '/' . $app3dsxBlobName; //Get Azure blob URL
-					
-					$app3dsxFile = fopen($app3dsxPath, 'r');
-					$blobRestProxy->createBlockBlob(getConfigValue('azure_container_3dsx'), $app3dsxBlobName, $app3dsxFile); //Upload blob to Azure Blob Service
-					fclose($app3dsxFile);
+					$app3dsxBlob->upload($blobRestProxy, getConfigValue('azure_container_3dsx'), $app3dsxPath);
+					$app3dsxBlob->closeFileHandle();
 				}
 				
+				$appSmdhBlob = new blob();
+				$appIconBlob = new blob();
 				if (!$updatingApp || $updatingSmdh) {
-					$appSmdhMD5 = md5_file($appSmdhPath);
-					$appSmdhBlobName = generateRandomString();
-					$appSmdhBlobURL = 'https://' . getConfigValue('azure_storage_account') . '.blob.core.windows.net/' . getConfigValue('azure_container_smdh') . '/' . $appSmdhBlobName;
-					
-					$appSmdhFile = fopen($appSmdhPath, 'r');
-					$blobRestProxy->createBlockBlob(getConfigValue('azure_container_smdh'), $appSmdhBlobName, $appSmdhFile);
+					$appSmdhBlob->upload($blobRestProxy, getConfigValue('azure_container_smdh'), $appSmdhPath);
 					
 					//Upload large PNG icon (we don't include the small one because it's often improperly encoded(?))
-					$smdhData = new smdh($appSmdhFile);
+					$smdhData = new smdh($appSmdhBlob->fileHandle);
 					
-					$appPNG = tmpfile(); //Create temporary file to save PNG
-					imagepng($smdhData->getLargeIcon(), stream_get_meta_data($appPNG)['uri']);
+					$appIcon = tmpfile(); //Create temporary file to save PNG
+					imagepng($smdhData->getLargeIcon(), stream_get_meta_data($appIcon)['uri']);
 					
-					$appPNGBlobName = generateRandomString();
-					$appPNGBlobURL = 'https://' . getConfigValue('azure_storage_account') . '.blob.core.windows.net/' . getConfigValue('azure_container_largeicon') . '/' . $appPNGBlobName;
-					$blobRestProxy->createBlockBlob(getConfigValue('azure_container_largeicon'), $appPNGBlobName, $appPNG);
+					$appIconBlob->upload($blobRestProxy, getConfigValue('azure_container_largeicon'), stream_get_meta_data($appIcon)['uri']);
 					
-					fclose($appPNG);
-					fclose($appSmdhFile);
+					$appIconBlob->closeFileHandle();
+					$appSmdhBlob->closeFileHandle();
 					$smdhData = null;
 				}
 				
-				if (is_uploaded_file($appDataPath)) {
-					$appDataMD5 = md5_file($appDataPath);
-					$appDataBlobName = generateRandomString();
-					$appDataBlobURL = 'https://' . getConfigValue('azure_storage_account') . '.blob.core.windows.net/' . getConfigValue('azure_container_appdata') . '/' . $appDataBlobName;
-					
-					$appDataFile = fopen($appDataPath, 'r');
-					$blobRestProxy->createBlockBlob(getConfigValue('azure_container_appdata'), $appDataBlobName, $appDataFile);
-					fclose($appDataFile);
+				$appDataBlob = new blob();
+				if ($updatingAppData) {
+					$appDataBlob->upload($blobRestProxy, getConfigValue('azure_container_appdata'), $appDataPath);
+					$appDataBlob->closeFileHandle();
 				}
 				else if (!$updatingApp) {
-					$appDataBlobURL = null;
-					$appDataMD5 = null;
+					$appDataBlob->url = null;
+					$appDataBlob->md5 = null;
 				}
+				
+				//TODO: Allow screenshot uploads
 				
 				if ($updatingApp) {
 					$currentVersion = getArrayFromSQLQuery($mysqlConn, 'SELECT appver.versionId, appver.3dsx, appver.smdh, appver.appdata, appver.largeIcon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5 FROM appversions appver
@@ -138,27 +147,27 @@
 					}
 					if (!$updatingSmdh) {
 						//Get current smdh URL and MD5, plus icon URL
-						$appSmdhBlobURL = $currentVersion['smdh'];
-						$appSmdhMD5 = $currentVersion['smdh_md5'];
-						$appPNGBlobURL = $currentVersion['largeIcon'];
+						$appSmdhBlob->url = $currentVersion['smdh'];
+						$appSmdhBlob->md5 = $currentVersion['smdh_md5'];
+						$appIconBlob->url = $currentVersion['largeIcon'];
 					}
 					
 					if (!$updating3dsx && $updatingAppData) {
 						//Get current 3dsx URL and MD5
-						$app3dsxBlobURL = $currentVersion['3dsx'];
-						$app3dsxMD5 = $currentVersion['3dsx_md5'];
+						$app3dsxBlob->url = $currentVersion['3dsx'];
+						$app3dsxBlob->md5 = $currentVersion['3dsx_md5'];
 					}
 					else if (!$updatingAppData && $updating3dsx) {
 						//Get current appdata URL and MD5
-						$appDataBlobURL = $currentVersion['appdata'];
-						$appDataMD5 = $currentVersion['appdata_md5'];
+						$appDataBlob->url = $currentVersion['appdata'];
+						$appDataBlob->md5 = $currentVersion['appdata_md5'];
 					}
 				}
 				
 				if (!$updatingApp || $updating3dsx || $updatingAppData) {
 					//Insert app version
 					$stmt = executePreparedSQLQuery($mysqlConn, 'INSERT INTO appversions (appGuid, number, 3dsx, smdh, appdata, largeIcon, 3dsx_md5, smdh_md5, appdata_md5)
-															VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', 'sssssssss', [$guid, $appVersion, $app3dsxBlobURL, $appSmdhBlobURL, $appDataBlobURL, $appPNGBlobURL, $app3dsxMD5, $appSmdhMD5, $appDataMD5], true);
+															VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', 'sssssssss', [$guid, $appVersion, $app3dsxBlob->url, $appSmdhBlob->url, $appDataBlob->url, $appIconBlob->url, $app3dsxBlob->md5, $appSmdhBlob->md5, $appDataBlob->md5], true);
 					$versionId = $stmt->insert_id;
 					$stmt->close();
 				}
@@ -166,7 +175,7 @@
 					//Update current app version with smdh URL and MD5
 					$stmt = executePreparedSQLQuery($mysqlConn, 'UPDATE appversions appver INNER JOIN apps app ON appver.versionId = app.version
 																	SET versionId = app.version, smdh = ?, largeIcon = ?, smdh_md5 = ?
-																	WHERE app.guid = ? AND appver.versionId = app.version', 'ssss', [$guid, $appSmdhBlobURL, $appPNGBlobURL, $appSmdhMD5]);
+																	WHERE app.guid = ? AND appver.versionId = app.version', 'ssss', [$guid, $appSmdhBlob->url, $appIconBlob->url, $appSmdhBlob->md5]);
 				}
 				
 				if (!$updatingApp) {

--- a/secure/action_publish.php
+++ b/secure/action_publish.php
@@ -84,7 +84,7 @@
 				
 				//Check which screenshots were uploaded
 				$screenshotsUploaded = array();
-				for ($i = 1; $i <= 4; $i++) {
+				for ($i = 1; $i <= getConfigValue('downloadmii_max_screenshots'); $i++) {
 					array_push($screenshotsUploaded, isset($_FILES['scr' . $i]) && is_uploaded_file($_FILES['scr' . $i]['tmp_name']));
 				}
 				
@@ -197,7 +197,7 @@
 				
 				unset($_SESSION['publish_app_guid' . $_POST['guidid']]);
 				
-				for ($i = 1; $i <= 4; $i++) {
+				for ($i = 1; $i <= getConfigValue('downloadmii_max_screenshots'); $i++) {
 					//If screenshot is uploaded...
 					if ($screenshotsUploaded[$i - 1]) {
 						//...push it to storage and insert/update a database row for it

--- a/secure/action_publish.php
+++ b/secure/action_publish.php
@@ -84,7 +84,7 @@
 				
 				//Check which screenshots were uploaded
 				$screenshotsUploaded = array();
-				for ($i = 1; $i <= 3; $i++) {
+				for ($i = 1; $i <= 4; $i++) {
 					array_push($screenshotsUploaded, isset($_FILES['scr' . $i]) && is_uploaded_file($_FILES['scr' . $i]['tmp_name']));
 				}
 				
@@ -197,7 +197,7 @@
 				
 				unset($_SESSION['publish_app_guid' . $_POST['guidid']]);
 				
-				for ($i = 1; $i <= 3; $i++) {
+				for ($i = 1; $i <= 4; $i++) {
 					//If screenshot is uploaded...
 					if ($screenshotsUploaded[$i - 1]) {
 						//...push it to storage and insert/update a database row for it

--- a/secure/publish.php
+++ b/secure/publish.php
@@ -105,7 +105,7 @@
 					<label for="description">Description (300 character limit):</label>
 					<textarea class="form-control" id="description" name="description" rows="6" maxlength="300"><?php printAttributeValueFromChoices(@$_POST['description'], $appToEdit['description'], false); ?></textarea>
 				</div>
-				<div class="row">
+				<div class="row" style="margin-bottom: 48px;">
 					<div class="col-md-4 form-group">
 						<label for="3dsx">3dsx file<?php if ($editing) echo ' (only upload if you want to update)'; ?>:</label>
 						<input type="file" class="filestyle" id="3dsx" name="3dsx" accept=".3dsx"<?php if (!$editing) echo ' required'; ?>>
@@ -134,7 +134,7 @@
 								
 								echo
 									'):</label>
-									<input type="file" class="filestyle" id="scr' . $imageIndex . '" name="scr' . $imageIndex . '">
+									<input type="file" class="filestyle" id="scr' . $imageIndex . '" name="scr' . $imageIndex . '" accept=".jpg,.jpeg,.png">
 								</div>';
 							}
 						}
@@ -143,6 +143,9 @@
 				?>
 				
 				<div class="form-group">
+					Please only post screenshots of either only the top screen or both screens. They should also be 1:1 to the 3DS screen resolutions.
+				</div>
+				<div class="form-group" style="margin-top: 48px;">
 					<div class="g-recaptcha" data-sitekey="<?php echo getConfigValue('apikey_recaptcha_site'); ?>"></div>
 				</div>
 				<div class="form-group">

--- a/secure/publish.php
+++ b/secure/publish.php
@@ -119,23 +119,27 @@
 						<input type="file" class="filestyle" id="appdata" name="appdata" accept=".zip">
 					</div>
 				</div>
-				<div class="row">
-					<?php
-						for ($i = 1; $i <= 3; $i++) {
+				<?php
+					for ($i = 0; $i < 2; $i++) {
+						echo '<div class="row">';
+						for ($j = 1; $j <= 2; $j++) {
+							$imageIndex = $i * 2 + $j;
+							
 							echo
-							'<div class="col-md-4 form-group">
-								<label for="scr' . $i . '">Screenshot ' . $i . ' (optional';
+							'<div class="col-md-6 form-group">
+								<label for="scr' . $imageIndex . '">Screenshot ' . $imageIndex . ' (optional';
 							
 							if ($editing) echo ', only upload if you want to update';
 							
 							echo
 								'):</label>
-								<input type="file" class="filestyle" id="scr' . $i . '" name="scr' . $i . '">
-							</div>
-							';
+								<input type="file" class="filestyle" id="scr' . $imageIndex . '" name="scr' . $imageIndex . '">
+							</div>';
 						}
-					?>
-				</div>
+						echo '</div>';
+					}
+				?>
+				
 				<div class="form-group">
 					<div class="g-recaptcha" data-sitekey="<?php echo getConfigValue('apikey_recaptcha_site'); ?>"></div>
 				</div>

--- a/secure/publish.php
+++ b/secure/publish.php
@@ -19,7 +19,7 @@
 		
 		$appToEdit = null;
 		if (isset($_GET['guid'], $_GET['token'], $myappsToken) && md5($myappsToken) === $_GET['token']) {
-			$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.publisher, app.version, app.description, app.category, app.subcategory, app.rating, app.downloads, app.publishstate,
+			$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.description, app.category, app.subcategory, app.rating, app.downloads, app.publishstate,
 																appver.number AS version FROM apps app
 																LEFT JOIN appversions appver ON appver.versionId = app.version
 																WHERE app.guid = ? AND app.publisher = ? LIMIT 1', 'ss', [$_GET['guid'], $_SESSION['user_id']]); //Get app with user/GUID combination

--- a/secure/publish.php
+++ b/secure/publish.php
@@ -120,21 +120,23 @@
 					</div>
 				</div>
 				<?php
-					for ($i = 0; $i < 2; $i++) {
+					for ($i = 0; $i < ceil(getConfigValue('downloadmii_max_screenshots') / 2); $i++) {
 						echo '<div class="row">';
 						for ($j = 1; $j <= 2; $j++) {
 							$imageIndex = $i * 2 + $j;
 							
-							echo
-							'<div class="col-md-6 form-group">
-								<label for="scr' . $imageIndex . '">Screenshot ' . $imageIndex . ' (optional';
-							
-							if ($editing) echo ', only upload if you want to update';
-							
-							echo
-								'):</label>
-								<input type="file" class="filestyle" id="scr' . $imageIndex . '" name="scr' . $imageIndex . '">
-							</div>';
+							if ($imageIndex < getConfigValue('downloadmii_max_screenshots') + 1) {
+								echo
+								'<div class="col-md-6 form-group">
+									<label for="scr' . $imageIndex . '">Screenshot ' . $imageIndex . ' (optional';
+								
+								if ($editing) echo ', only upload if you want to update';
+								
+								echo
+									'):</label>
+									<input type="file" class="filestyle" id="scr' . $imageIndex . '" name="scr' . $imageIndex . '">
+								</div>';
+							}
 						}
 						echo '</div>';
 					}

--- a/secure/publish.php
+++ b/secure/publish.php
@@ -119,6 +119,23 @@
 						<input type="file" class="filestyle" id="appdata" name="appdata" accept=".zip">
 					</div>
 				</div>
+				<div class="row">
+					<?php
+						for ($i = 1; $i <= 3; $i++) {
+							echo
+							'<div class="col-md-4 form-group">
+								<label for="scr' . $i . '">Screenshot ' . $i . ' (optional';
+							
+							if ($editing) echo ', only upload if you want to update';
+							
+							echo
+								'):</label>
+								<input type="file" class="filestyle" id="scr' . $i . '" name="scr' . $i . '">
+							</div>
+							';
+						}
+					?>
+				</div>
 				<div class="form-group">
 					<div class="g-recaptcha" data-sitekey="<?php echo getConfigValue('apikey_recaptcha_site'); ?>"></div>
 				</div>


### PR DESCRIPTION
Added #25 and screenshot uploading. The app pages also have breadcrumb support (#24).

App page screenshot:
![](http://i.imgur.com/4e2aew4.png)

New config values:
* azure_container_screenshots
* downloadmii_max_screenshots (default 4)

New SQL:
```sql
CREATE TABLE screenshots(
	screenshotId INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
	appGuid CHAR(36) NOT NULL,
	imageIndex TINYINT NOT NULL,
	url VARCHAR(255) NOT NULL,
	
	PRIMARY KEY(appGuid, imageIndex);
	
	FOREIGN KEY (appGuid) REFERENCES apps(guid)
);
```

Problems:
* The code is a bit messy
* Not 100% complete (although it should be ready for deployment)
* How will the 3DS app display screenshots? (libpng? conversion to raw rgb when uploading?) This also applies to the app icons we introduced earlier.