### PR TITLE
Publishing update

### DIFF
--- a/apps/app.php
+++ b/apps/app.php
@@ -19,7 +19,7 @@
 														LEFT JOIN categories subcat ON subcat.categoryId = app.subcategory
 														LEFT JOIN screenshots scr ON scr.appGuid = app.guid
 														WHERE (app.publishstate = 1 OR app.publishstate = 4 OR app.publishstate = 5) AND app.guid = ?
-														GROUP BY app.guid', 's', [$appGuid]);
+														GROUP BY app.guid LIMIT 1', 's', [$appGuid]);
 	
 	printAndExitIfTrue(count($matchingApps) !== 1, 'Invalid app GUID.');
 	$app = $matchingApps[0];

--- a/apps/app.php
+++ b/apps/app.php
@@ -11,7 +11,7 @@
 	$appGuid = rtrim(substr($requestUri, strlen('/apps/view/')), '/');
 	
 	$mysqlConn = connectToDatabase();
-	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.description, app.downloads, app.publishstate, app.failpublishmessage,
+	$matchingApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.name, app.description, app.downloads, app.webicon, app.publishstate, app.failpublishmessage,
 														user.nick AS publisher, appver.number AS version, appver.largeIcon, maincat.name AS category, subcat.name AS subcategory, group_concat(scr.url) AS screenshots FROM apps app
 														LEFT JOIN users user ON user.userId = app.publisher
 														LEFT JOIN appversions appver ON appver.versionId = app.version
@@ -57,7 +57,7 @@
 		<div vocab="http://schema.org/" typeof="SoftwareApplication">
 			<div class="app-header">
 				<div class="app-vertical-center-outer pull-left">
-					<img class="app-icon" src="<?php if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
+					<img class="app-icon" src="<?php if (!empty($app['webicon'])) echo $app['webicon']; else if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
 					<div class="pull-right">
 						<h4 class="app-name app-vertical-center-inner">
 							<span itemprop="name">
@@ -85,7 +85,7 @@
 				$screenshots = explode(',', $app['screenshots']);
 			?>
 			<div class="row">
-				<div class="clear-float col-sm-6 col-xs-12">
+				<div class="clearfix col-sm-6 col-xs-12">
 					<div id="carousel-appScr" class="carousel slide" data-ride="carousel" style="max-width:400px;">
 						<ol class="carousel-indicators">
 						<?php
@@ -130,7 +130,7 @@
 			}
 			else {
 			?>
-				<div class="app-desc clear-float" style="padding-top:8px">
+				<div class="app-desc clearfix" style="padding-top:8px">
 					<?php
 						echo $desc;
 					?>

--- a/apps/index.php
+++ b/apps/index.php
@@ -9,7 +9,7 @@
 	$page = 'AppView';
 	require_once('../common/uiheader.php');
 	
-	$mysqlQuery = 'SELECT app.guid, app.name, app.description, app.downloads, app.publishstate, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
+	$mysqlQuery = 'SELECT app.guid, app.name, app.description, app.downloads, app.webicon, app.publishstate, user.nick AS publisher, appver.number AS version, appver.largeIcon FROM apps app
 					LEFT JOIN users user ON user.userId = app.publisher
 					LEFT JOIN appversions appver ON appver.versionId = app.version
 					LEFT JOIN categories maincat ON maincat.categoryId = app.category
@@ -60,7 +60,7 @@
 	<a href="/apps/view/<?php echo $app['guid'] ?>" style="color: black;max-width:100%">
 		<div itemscope itemtype="http://schema.org/SoftwareApplication" class="col-sm-2 col-xs-6 app-view" style="height:280px;margin-bottom:30px">
 			<div style="max-width:100%;overflow:hidden;white-space:nowrap;">
-				<img class="app-icon" alt="App logo" src="<?php if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>"/>
+				<img class="app-icon" alt="App logo" src="<?php if (!empty($app['webicon'])) echo $app['webicon']; else if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>"/>
 				<div class="app-content app-vertical-center-outer pull-left" style="padding:0 10px;background:#f3f3f3;width:100%;">
 					<div class="pull-left">
 						<h4 class="app-vertical-center-inner">

--- a/common/uiheader.php
+++ b/common/uiheader.php
@@ -25,10 +25,6 @@
 				max-width: 1060px;
 			}
 			
-			.clear-float {
-				clear: both;
-			}
-			
 			.no-border-radius {
 				border-radius: 0;
 			}

--- a/config.template.php
+++ b/config.template.php
@@ -11,6 +11,7 @@
 		'azure_container_smdh' => '',
 		'azure_container_appdata' => '',
 		'azure_container_largeicon' => '',
+		'azure_container_webicon' => '',
 		'azure_container_screenshots' => '',
 		
 		//MySQL

--- a/doc/DB/dwnmii.sql
+++ b/doc/DB/dwnmii.sql
@@ -58,6 +58,7 @@ CREATE TABLE apps(
 	subcategory INT NULL,
 	rating TINYINT NOT NULL DEFAULT 0,
 	downloads INT NOT NULL DEFAULT 0,
+	webicon VARCHAR(255) NULL,
 	publishstate TINYINT NOT NULL DEFAULT 0,				-- Use bitwise operations in the future?
 	failpublishmessage VARCHAR(24) NULL,
 	

--- a/secure/myapps/index.php
+++ b/secure/myapps/index.php
@@ -8,7 +8,7 @@
 	
 	if (clientLoggedIn()) {
 		$mysqlConn = connectToDatabase();
-		$userApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.description, app.downloads, app.publishstate, app.failpublishmessage, appver.number AS version, appver.largeIcon, appver_new.number AS version_new FROM apps app
+		$userApps = getArrayFromSQLQuery($mysqlConn, 'SELECT app.guid, app.name, app.description, app.downloads, app.webicon, app.publishstate, app.failpublishmessage, appver.number AS version, appver.largeIcon, appver_new.number AS version_new FROM apps app
 														LEFT JOIN appversions appver ON appver.versionId = app.version
 														LEFT JOIN appversions appver_new ON appver_new.versionId = (SELECT versionId FROM appversions WHERE appGuid = app.guid ORDER BY versionId DESC LIMIT 1)
 														WHERE app.publisher = ? ORDER BY appver.versionId DESC', 'i', [$_SESSION['user_id']]);
@@ -24,7 +24,7 @@
 ?>
 		<div class="well clearfix">
 			<div class="app-vertical-center-outer pull-left">
-				<img class="app-icon" src="<?php if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
+				<img class="app-icon" src="<?php if (!empty($app['webicon'])) echo $app['webicon']; else if (!empty($app['largeIcon'])) echo $app['largeIcon']; else echo '/img/no_icon.png'; ?>" />
 				<div class="pull-right">
 					<h4 class="app-name app-vertical-center-inner">
 						<span itemprop="name">

--- a/secure/notifications/index.php
+++ b/secure/notifications/index.php
@@ -30,34 +30,34 @@
 ?>
 
 		<div class="well clearfix">
-			<div class="pull-left">
-				<h4><strong>
-<?php
-				if (!$notification->isRead) {
-					echo '<span class="badge">!</span> '; //Display an indicator for unread notifications
-				}
+			<div class="clearfix">
+				<div class="pull-left">
+					<h4><strong>
+	<?php
+					if (!$notification->isRead) {
+						echo '<span class="badge">!</span> '; //Display an indicator for unread notifications
+					}
 
-				if (!empty($notification->url)) {
-					echo '<a href="' . $notification->url . '">' . $notification->summary . '</a>';
-				}
-				else {
-					echo $notification->summary;
-				}
-?>
-				</strong></h4>
-			</div>
-			<div class="app-vertical-center-outer pull-right">
-				<div class="app-vertical-center-inner">
-<?php
-			echo $notification->timeCreated;
-?>
+					if (!empty($notification->url)) {
+						echo '<a href="' . $notification->url . '">' . $notification->summary . '</a>';
+					}
+					else {
+						echo $notification->summary;
+					}
+	?>
+					</strong></h4>
+				</div>
+				<div class="app-vertical-center-outer pull-right">
+					<div class="app-vertical-center-inner">
+	<?php
+				echo $notification->timeCreated;
+	?>
+					</div>
 				</div>
 			</div>
-			<div class="clear-float">
 <?php
 			echo $notification->body;
 ?>
-			</div>
 		</div>
 <?php
 	}

--- a/secure/publish/action.php
+++ b/secure/publish/action.php
@@ -90,6 +90,7 @@
 	}
 
 	function deletingFile($fileId) {
+		return $updatingApp && isset($_POST['del_' . $fileId]) && $_POST['del_' . $fileId] === 'yes';
 	}
 	
 	if (isset($_POST['guidid'], $_SESSION['publish_app_guid' . $_POST['guidid']])) {
@@ -239,10 +240,10 @@
 																		LEFT JOIN apps app ON appver.versionId = app.version
 																		WHERE app.guid = ? LIMIT 1', 's', [$guid])[0];
 					$currentVersionId = $currentVersion['versionId'];
-
+					
 					$currentApp = getArrayFromSQLQuery($mysqlConn, 'SELECT webicon, publishstate FROM apps WHERE guid = ? LIMIT 1', 's', [$guid])[0];
 					$currentPublishState = $currentApp['publishstate'];
-					
+
 					if (!$updatingSmdh) {
 						//Get current smdh URL and MD5, plus icon URL
 						$appSmdhBlob->url = $currentVersion['smdh'];
@@ -343,6 +344,7 @@
 					}
 
 					//Delete screenshot if desired
+					if (deletingFile('scr' . $i)) {
 						$matchingScreenshotsToDelete = getArrayFromSQLQuery($mysqlConn, 'SELECT url FROM screenshots
 																			WHERE appGuid = ? AND imageIndex = ?',
 																			'si', [$guid, $i]);

--- a/secure/publish/action.php
+++ b/secure/publish/action.php
@@ -260,9 +260,6 @@
 						$appDataBlob->url = $currentVersion['appdata'];
 						$appDataBlob->md5 = $currentVersion['appdata_md5'];
 					}
-					else if (deletingFile('appdata') && !empty($currentVersion['appdata'])) {
-						$blobRestProxy->deleteBlob(getConfigValue('azure_container_appdata'), $currentVersion['appdata']);
-					}
 
 					if (!$uploadingWebIcon) {
 						//Get current webicon URL and MD5

--- a/secure/publish/action.php
+++ b/secure/publish/action.php
@@ -29,43 +29,64 @@
 			fclose($this->fileHandle);
 		}
 	}
-	
-	function processScreenshot($filename) {
-		$originalSizeInfo = getimagesize($filename); //Get input image size and MIME information
+
+	function processImage($path, $type)
+	{
+		//Get input image size and MIME information
+		$originalSizeInfo = getimagesize($path);
 		$originalWidth = $originalSizeInfo[0];
 		$originalHeight = $originalSizeInfo[1];
 		$originalMIME = $originalSizeInfo['mime'];
-		
-		if ($originalWidth !== 400 || ($originalHeight !== 240 && $originalHeight !== 480)) { //If width isn't 400, and height isn't 240 or 480...
+
+		//Get image data
+		$originalImage = null;
+		switch ($originalMIME) {
+			case 'image/jpeg':
+				$originalImage = imagecreatefromjpeg($path);
+				break;
+
+			case 'image/png':
+				$originalImage = imagecreatefrompng($path);
+				break;
+
+			default:
+				throw new Exception('Invalid image file type.');
+				break;
+		}
+
+		//Set desired resolution according to type
+		switch ($type) {
+			case 'webicon':
+				$newWidth = 400;
+				$newHeight = 400;
+				break;
+
+			case 'screenshot':
+				$scale = 400 / $originalWidth; //Calculate horizontal scaling
+				$newWidth = 400;
+				$newHeight = $originalHeight * $scale / 480 >= 0.75 ? 480 : 240; //Estimate if the image is of the top screen only or both screens, and adjust the height for that
+				break;
+
+			default:
+				throw new Exception('Invalid image processing type.');
+				break;
+		}
+
+		$retFile = tmpfile(); //Create temporary file to save PNG
+
+		if ($originalWidth !== 400 || ($originalHeight !== 240 && $originalHeight !== 480)) { //If width and height doesn't match desired values...
 			//...do some resizing
-			
-			$image = null;
-			switch ($originalMIME) {
-				case 'image/jpeg':
-					$image = imagecreatefromjpeg($filename);
-					break;
-				
-				case 'image/png':
-					$image = imagecreatefrompng($filename);
-					break;
-			}
-			
-			$scale = 400 / $originalWidth; //Calculate horizontal scaling
-			$newWidth = 400;
-			$newHeight = $originalHeight * $scale / 480 >= 0.75 ? 480 : 240; //Estimate if the image is of the top screen only or both screens, and adjust the height for that
-			
 			$resizedImage = imagecreatetruecolor($newWidth, $newHeight);
-			imagecopyresampled($resizedImage, $image, 0, 0, 0, 0, $newWidth, $newHeight, $originalWidth, $originalHeight); //Resize the image
-			
-			$screenshot = tmpfile(); //Create temporary file to save PNG
-			imagepng($resizedImage, stream_get_meta_data($screenshot)['uri']); //Save processed screenshot
+			imagecopyresampled($resizedImage, $originalImage, 0, 0, 0, 0, $newWidth, $newHeight, $originalWidth, $originalHeight); //Resize the image
+
+			imagepng($resizedImage, stream_get_meta_data($retFile)['uri']); //Save processed screenshot
 			imagedestroy($resizedImage);
-			
-			return $screenshot; //Return temporary screenshot file handle
 		}
 		else {
-			return fopen($filename, 'r'); //We didn't do anything, return the file handle of the original screenshot
+			imagepng($originalImage, stream_get_meta_data($retFile)['uri']); //Save original screenshot
 		}
+
+		return $retFile; //Return temporary screenshot file handle
 	}
 	
 	if (isset($_POST['guidid'], $_SESSION['publish_app_guid' . $_POST['guidid']])) {
@@ -111,11 +132,14 @@
 				$app3dsxPath = $_FILES['3dsx']['tmp_name'];
 				$appSmdhPath = $_FILES['smdh']['tmp_name'];
 				$appDataPath = $_FILES['appdata']['tmp_name'];
+				$webIconPath = $_FILES['webicon']['tmp_name'];
 				
 				$isDeveloper = clientPartOfGroup('Developers');
 				$updatingApp = isset($_SESSION['user_app_version' . $guid]);
 				
-				$updatingAppData = is_uploaded_file($appDataPath);
+				$uploadingAppData = is_uploaded_file($appDataPath);
+				$uploadingWebIcon = is_uploaded_file($webIconPath);
+
 				if (!$updatingApp) {
 					throwExceptionIfTrue(!is_uploaded_file($app3dsxPath) || !is_uploaded_file($appSmdhPath), 'Please upload the required files.');
 				}
@@ -124,9 +148,15 @@
 					$updatingSmdh = is_uploaded_file($appSmdhPath);
 					
 					//Check that if 3dsx/appdata is changed, the version also is
-					throwExceptionIfTrue($_SESSION['user_app_version' . $guid] === $_POST['version'] && ($updating3dsx || $updatingAppData), 'Please also update the version number when uploading a new 3dsx/appdata file.');
+					throwExceptionIfTrue($_SESSION['user_app_version' . $guid] === $_POST['version'] && ($updating3dsx || $uploadingAppData), 'Please also update the version number when uploading a new 3dsx/appdata file.');
 				}
-				
+
+				//Verify web icon file type
+				if ($uploadingWebIcon) {
+					$imageMIME = getimagesize($_FILES['webicon'])['mime'];
+					throwExceptionIfTrue(!($imageMIME && ($imageMIME === 'image/jpeg' || $imageMIME === 'image/png')), 'Invalid hi-res icon file type. It must be in JPEG or PNG format.');
+				}
+
 				//Check which screenshots were uploaded
 				$screenshotsUploaded = array();
 				for ($i = 1; $i <= getConfigValue('downloadmii_max_screenshots'); $i++) {
@@ -153,7 +183,7 @@
 				}
 				
 				//Initialize Azure Blob Service if files will be uploaded
-				if (!$updatingApp || $updating3dsx || $updatingSmdh || $updatingAppData || count($screenshotsUploaded) > 0) {
+				if (!$updatingApp || $updating3dsx || $updatingSmdh || $uploadingAppData || count($screenshotsUploaded) > 0) {
 					$blobRestProxy = ServicesBuilder::getInstance()->createBlobService(getConfigValue('azure_connection_string'));
 				}
 				
@@ -182,7 +212,7 @@
 				}
 				
 				$appDataBlob = new blob();
-				if ($updatingAppData) {
+				if ($uploadingAppData) {
 					$appDataBlob->upload($blobRestProxy, getConfigValue('azure_container_appdata'), $appDataPath);
 					$appDataBlob->closeFileHandle();
 				}
@@ -190,15 +220,25 @@
 					$appDataBlob->url = null;
 					$appDataBlob->md5 = null;
 				}
+
+				$webIconBlob = new blob();
+				if ($uploadingWebIcon) {
+					$processedWebIconHandle = processImage($_FILES['webicon']['tmp_name'], 'webicon');
+					$webIconBlob->upload($blobRestProxy, getConfigValue('azure_container_webicon'), $processedWebIconHandle);
+					$webIconBlob->closeFileHandle();
+				}
+				else if (!$updatingApp) {
+					$webIconBlob->url = null;
+				}
 				
 				if ($updatingApp) {
-					$currentVersion = getArrayFromSQLQuery($mysqlConn, 'SELECT appver.versionId, appver.3dsx, appver.smdh, appver.appdata, appver.largeIcon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5 FROM appversions appver
+					$currentVersion = getArrayFromSQLQuery($mysqlConn, 'SELECT appver.versionId, appver.3dsx, appver.smdh, appver.appdata, appver.largeIcon, appver.3dsx_md5, appver.smdh_md5, appver.appdata_md5, app.webicon FROM appversions appver
 																		LEFT JOIN apps app ON appver.versionId = app.version
 																		WHERE app.guid = ? LIMIT 1', 's', [$guid])[0];
-					
 					$currentVersionId = $currentVersion['versionId'];
 					
-					$currentPublishState = getArrayFromSQLQuery($mysqlConn, 'SELECT publishstate FROM apps WHERE guid = ? LIMIT 1', 's', [$guid])[0]['publishstate'];
+					$currentApp = getArrayFromSQLQuery($mysqlConn, 'SELECT webicon, publishstate FROM apps WHERE guid = ? LIMIT 1', 's', [$guid])[0];
+					$currentPublishState = $currentApp['publishstate'];
 					
 					if (!$updatingSmdh) {
 						//Get current smdh URL and MD5, plus icon URL
@@ -212,15 +252,20 @@
 						$app3dsxBlob->url = $currentVersion['3dsx'];
 						$app3dsxBlob->md5 = $currentVersion['3dsx_md5'];
 					}
-					
-					if (!$updatingAppData) {
+
+					if (!$uploadingAppData) {
 						//Get current appdata URL and MD5
 						$appDataBlob->url = $currentVersion['appdata'];
 						$appDataBlob->md5 = $currentVersion['appdata_md5'];
 					}
+
+					if (!$uploadingWebIcon) {
+						//Get current appdata URL and MD5
+						$webIconBlob->url = $currentApp['webicon'];
+					}
 				}
 				
-				if (!$updatingApp || $updating3dsx || $updatingSmdh || $updatingAppData) {
+				if (!$updatingApp || $updating3dsx || $updatingSmdh || $uploadingAppData) {
 					//Insert app version
 					$stmt = executePreparedSQLQuery($mysqlConn, 'INSERT INTO appversions (appGuid, number, 3dsx, smdh, appdata, largeIcon, 3dsx_md5, smdh_md5, appdata_md5)
 																	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', 'sssssssss', [$guid, $appVersion, $app3dsxBlob->url, $appSmdhBlob->url, $appDataBlob->url, $appIconBlob->url, $app3dsxBlob->md5, $appSmdhBlob->md5, $appDataBlob->md5], true);
@@ -233,11 +278,11 @@
 					
 					$publishState = $isDeveloper ? 1 : 0;
 					
-					executePreparedSQLQuery($mysqlConn, 'INSERT INTO apps (guid, name, publisher, version, description, category, subcategory, publishstate)
-															VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
-															'ssiisiii', [$guid, $appName, $_SESSION['user_id'], $versionId, $appDescription, $appCategory, $appSubCategory, $publishState]);
+					executePreparedSQLQuery($mysqlConn, 'INSERT INTO apps (guid, name, publisher, version, description, category, subcategory, webicon, publishstate)
+															VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+															'ssiisiisi', [$guid, $appName, $_SESSION['user_id'], $versionId, $appDescription, $appCategory, $appSubCategory, $webIconBlob->url, $publishState]);
 				}
-				else if ($updating3dsx || $updatingSmdh || $updatingAppData) {
+				else if ($updating3dsx || $updatingSmdh || $uploadingAppData) {
 					//Update app row, including version and publish state
 					
 					if ($currentPublishState !== 0) {
@@ -252,18 +297,18 @@
 						$publishState = 0; //Pending approval
 					}
 					
-					executePreparedSQLQuery($mysqlConn, 'UPDATE apps SET name = ?, version = ?, description = ?, category = ?, subcategory = ?, publishstate = ?
+					executePreparedSQLQuery($mysqlConn, 'UPDATE apps SET name = ?, version = ?, description = ?, category = ?, subcategory = ?, webicon = ?, publishstate = ?
 															WHERE guid = ?',
-															'sisiiis', [$appName, $publishState === 1 ? $versionId : $currentVersionId, $appDescription, $appCategory, $appSubCategory, $publishState, $guid]);
+															'sisiisis', [$appName, $publishState === 1 ? $versionId : $currentVersionId, $appDescription, $appCategory, $appSubCategory, $webIconBlob->url, $publishState, $guid]);
 				}
 				else {
 					//Update app row, but keep current version and publish state
 					
 					$publishState = $currentPublishState;
 					
-					executePreparedSQLQuery($mysqlConn, 'UPDATE apps SET name = ?, description = ?, category = ?, subcategory = ?
+					executePreparedSQLQuery($mysqlConn, 'UPDATE apps SET name = ?, description = ?, category = ?, subcategory = ?, webicon = ?
 															WHERE guid = ?',
-															'ssiis', [$appName, $appDescription, $appCategory, $appSubCategory, $guid]);
+															'ssiiss', [$appName, $appDescription, $appCategory, $appSubCategory, $webIconBlob->url, $guid]);
 				}
 				
 				unset($_SESSION['publish_app_guid' . $_POST['guidid']]);
@@ -273,7 +318,7 @@
 					if ($screenshotsUploaded[$i - 1]) {
 						//...push it to storage and insert/update a database row for it
 						$appScreenshotBlob = new blob();
-						$processedScreenshotHandle = processScreenshot($_FILES['scr' . $i]['tmp_name']);
+						$processedScreenshotHandle = processImage($_FILES['scr' . $i]['tmp_name'], 'screenshot');
 						$appScreenshotBlob->upload($blobRestProxy, getConfigValue('azure_container_screenshots'), stream_get_meta_data($processedScreenshotHandle)['uri']);
 						$appScreenshotBlob->closeFileHandle();
 						
@@ -287,7 +332,7 @@
 				unset($_SESSION['myapps_token' . $guid]);
 				unset($_SESSION['publish_token' . $guid]);
 				
-				if ($isDeveloper || ($updatingApp && $currentPublishState === 1 && !$updating3dsx && !$updatingAppData)) {
+				if ($isDeveloper || ($updatingApp && $currentPublishState === 1 && !$updating3dsx && !$uploadingAppData)) {
 					echo 'Your application has been published.';
 				}
 				else {

--- a/secure/publish/index.php
+++ b/secure/publish/index.php
@@ -8,7 +8,7 @@
 	require_once('action.php');
 
 	function generateDeleteButtonHTML($fileId) {
-		echo '<input type="checkbox" id="del_' . $fileId . '" name="del_' . $fileId . '" onclick="updateFileButton(\'' . $fileId . '\')">
+		echo '<input type="checkbox" id="del_' . $fileId . '" name="del_' . $fileId . '" value="yes" onclick="updateFileButton(\'' . $fileId . '\')">
 				<label for="del_' . $fileId . '">Delete</label>';
 	}
 	


### PR DESCRIPTION
* Checkbox for deleting published optional files, all of them except appdata are permanently deleted (as discussed in #25)
* Hi-res app icons (resized to 400x400) can now be uploaded (again, as discussed in #25)
* Cleaner publishing page UI
* Lots of minor backend changes

I have tested the changes locally, and they seem to be bug-free.

<br />
**Before merging, execute this SQL:**

```sql
ALTER TABLE apps
ADD webicon VARCHAR(255) NULL AFTER downloads
```

**And update config.php by adding a value for this config key:**

`azure_container_webicon` (of course, you'll have to create that container)